### PR TITLE
Configure JupyterLab for Amp orbs

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+  python -m pip install --user uv
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+uv sync --all-packages --frozen
+
+mkdir -p \
+  "$HOME/.jupyter/jupyter_server_config.d" \
+  "$HOME/.jupyter/lab/user-settings/@jupyterlab/completer-extension"
+
+cat > "$HOME/.jupyter/jupyter_server_config.d/ty-language-server.json" <<'EOF'
+{
+  "LanguageServerManager": {
+    "language_servers": {
+      "ty": {
+        "version": 2,
+        "argv": ["ty", "server"],
+        "languages": ["python"],
+        "mime_types": ["text/python", "text/x-python", "text/x-ipython"],
+        "display_name": "ty"
+      }
+    }
+  }
+}
+EOF
+
+cat > "$HOME/.jupyter/lab/user-settings/@jupyterlab/completer-extension/manager.jupyterlab-settings" <<'EOF'
+{
+  "autoCompletion": true
+}
+EOF

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,7 +1,11 @@
 services:
   jupyter:
     command: >-
-      uv run --with jupyterlab --with jupyterlab-lsp
+      uv run
+      --with jupyterlab
+      --with jupyterlab-lsp
+      --with ipywidgets
+      --with jupyter-collaboration
       jupyter lab
       --ip=0.0.0.0
       --port=$PORT

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,16 @@
+services:
+  jupyter:
+    command: >-
+      uv run --with jupyterlab --with jupyterlab-lsp
+      jupyter lab
+      --ip=0.0.0.0
+      --port=$PORT
+      --no-browser
+      --IdentityProvider.token=
+      --ServerApp.password=
+      --ServerApp.allow_remote_access=True
+      --ServerApp.allow_origin_pat=^https://[A-Za-z0-9-]+[.]onamp[.]dev$
+      --ServerApp.root_dir=.
+    portal:
+      title: JupyterLab
+      description: JupyterLab with ty language-server completion for the Tilebox workspace.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 __pycache__/
 .ipynb_checkpoints/
+.virtual_documents/
 
 .idea/
 
@@ -18,4 +19,5 @@ test-report.xml
 
 *.egg-info/
 
-.amp/
+.amp/*
+!.amp/services.yaml


### PR DESCRIPTION
## Summary

- add an idempotent orb setup script that installs `uv`, syncs the workspace, registers `ty server` with Jupyter-LSP, and enables automatic completion
- declare JupyterLab as a supervised Amp portal service with `*.onamp.dev` origin handling
- ignore Jupyter-LSP virtual documents while keeping the service declaration tracked

## Verification

- ran `.agents/setup` twice (warm run completed in 0.02s)
- validated the setup script with `bash -n`
- parsed `.amp/services.yaml` successfully
- started the declared service with `amp orb services ensure`
- verified the portal returns HTTP 200
- verified the `ty` LSP session reaches `started` and exchanges client/server messages
